### PR TITLE
Dev

### DIFF
--- a/nchoosek/core.py
+++ b/nchoosek/core.py
@@ -263,6 +263,8 @@ class Environment(object):
         return len(raw.hard_failed) == 0
 
     def quality(self, soln):
+        '''Return the number of soft constraints which passed and the total
+        number of soft constraints.'''
         raw = self.validation(soln)
         soft = len(raw.soft_passed)
         total = soft + len(raw.soft_failed)

--- a/nchoosek/core.py
+++ b/nchoosek/core.py
@@ -261,3 +261,21 @@ class Environment(object):
         'Return True if all hard constraints are satisfied, False otherwise.'
         raw = self.validation(soln)
         return len(raw.hard_failed) == 0
+
+    def quality(self, soln):
+        raw = self.validation(soln)
+        soft = len(raw.soft_passed)
+        total = soft + len(raw.soft_failed)
+        return soft, total
+
+    class Result(object):
+        'Encapsulate the different results and other data.'
+
+        def __init__(self):
+            self.solutions = None
+            self.tallies = None
+            self.energies = None
+            self.jobs = None
+            self.jobIDs = None
+            self.qubits = None
+            self.depth = None

--- a/nchoosek/solver/ocean.py
+++ b/nchoosek/solver/ocean.py
@@ -22,7 +22,7 @@ def solve(env, sampler=None, hard_scale=None, **sampler_args):
     result = sampler.sample_qubo(qubo, **sampler_args)
 
     # Convert the result to a mapping from port names to Booleans and
-    # return it.
+    # record it, the number of occurences, and the energies.
     ports = env.ports()
     res = []
     num = []
@@ -31,9 +31,9 @@ def solve(env, sampler=None, hard_scale=None, **sampler_args):
         res.append({k: v != 0 for k, v in it.sample.items() if k in ports})
         num.append(it.num_occurrences)
         en.append(it.energy)
-    ret.energies = en
     ret.solutions = res
     ret.tallies = num
+    ret.energies = en
 
     # Insepct the embedding to find out how many qubits were used
     # Simulators will not have embedding_context even using dwave.inspector

--- a/nchoosek/solver/ocean.py
+++ b/nchoosek/solver/ocean.py
@@ -4,6 +4,7 @@
 ########################################
 
 from dwave.system import DWaveSampler, EmbeddingComposite
+import dwave.inspector
 from nchoosek.solver import construct_qubo
 
 
@@ -17,9 +18,32 @@ def solve(env, sampler=None, hard_scale=None, **sampler_args):
     qubo = construct_qubo(env, hard_scale)
 
     # Solve the QUBO using the given sampler.
+    ret = env.Result()
     result = sampler.sample_qubo(qubo, **sampler_args)
 
     # Convert the result to a mapping from port names to Booleans and
     # return it.
     ports = env.ports()
-    return {k: v != 0 for k, v in result.first.sample.items() if k in ports}
+    res = []
+    num = []
+    en = []
+    for it in result.data():
+        res.append({k: v != 0 for k, v in it.sample.items() if k in ports})
+        num.append(it.num_occurrences)
+        en.append(it.energy)
+    ret.energies = en
+    ret.solutions = res
+    ret.tallies = num
+
+    # Insepct the embedding to find out how many qubits were used
+    # Simulators will not have embedding_context even using dwave.inspector
+    try:
+        embed = result.info['embedding_context']['embedding']
+        nqubs = 0
+        for chain in embed.values():
+            nqubs += len(chain)
+    except KeyError:
+        nqubs = len(ports)
+    ret.qubits = nqubs
+
+    return ret

--- a/nchoosek/solver/qiskit.py
+++ b/nchoosek/solver/qiskit.py
@@ -5,6 +5,8 @@
 
 from nchoosek.solver import construct_qubo
 import qiskit
+import datetime
+import re
 from qiskit_optimization import QuadraticProgram
 from qiskit_optimization.algorithms import MinimumEigenOptimizer
 from qiskit.algorithms import QAOA
@@ -28,12 +30,36 @@ def solve(env, quantum_instance=None, hard_scale=None, optimizer=COBYLA()):
         prog.binary_var(var)
     prog.minimize(quadratic=qubo)
 
+    time1 = datetime.datetime.now()
     # This runs the problem as a QAOA.
     qaoa = MinimumEigenOptimizer(QAOA(optimizer=optimizer, reps=1,
                                  quantum_instance=quantum_instance))
     result = qaoa.solve(prog)
+    ret = env.Result()
+    time2 = datetime.datetime.now()
+
+    ret.solutions = []
+    ret.solutions.append({k: v != 0 for k, v in result.variables_dict.items() if k in env.ports()})
+    ret.tallies = [1]
+    try:
+        jobs = device.jobs(limit=50, start_datetime=time1, end_datetime=time2)
+        qasm = jobs[2].circuits()[0].qasm()
+        count = 0
+        # Qiskit jobs don't tell you how many physical qubits get used; need to search through the final qasm.
+        for i in range(device.configuration().n_qubits):
+            if re.search(r"cx[^;]*q\[" + str(i) + r"\]", qasm) or re.search(r"rz\([^\(]*\) q\[" + str(i) + r"\]", qasm):
+                count += 1
+
+        ret.jobIDs = []
+        for job in jobs:
+            ret.jobIDs.append(job.job_id())
+        ret.jobs = len(jobs)
+        ret.qubits = count
+        ret.depth = jobs[2].circuits()[0].depth()
+    except:
+        pass
 
     # Convert the result to a mapping from port names to Booleans and
     # return it.
     ports = env.ports()
-    return {k: v != 0 for k, v in result.variables_dict.items() if k in ports}
+    return ret

--- a/nchoosek/solver/qiskit.py
+++ b/nchoosek/solver/qiskit.py
@@ -36,16 +36,18 @@ def solve(env, quantum_instance=None, hard_scale=None, optimizer=COBYLA()):
                                  quantum_instance=quantum_instance))
     result = qaoa.solve(prog)
     ret = env.Result()
-    time2 = datetime.datetime.now()
 
     ret.solutions = []
     ret.solutions.append({k: v != 0 for k, v in result.variables_dict.items() if k in env.ports()})
+    # Record this time now to ensure that the QAOA is done running first.
+    time2 = datetime.datetime.now()
     ret.tallies = [1]
     try:
         jobs = device.jobs(limit=50, start_datetime=time1, end_datetime=time2)
         qasm = jobs[2].circuits()[0].qasm()
         count = 0
-        # Qiskit jobs don't tell you how many physical qubits get used; need to search through the final qasm.
+        # Qiskit jobs don't tell you how many physical qubits get used;
+        # we need to search through the final qasm.
         for i in range(device.configuration().n_qubits):
             if re.search(r"cx[^;]*q\[" + str(i) + r"\]", qasm) or re.search(r"rz\([^\(]*\) q\[" + str(i) + r"\]", qasm):
                 count += 1

--- a/nchoosek/solver/z3.py
+++ b/nchoosek/solver/z3.py
@@ -40,7 +40,9 @@ def direct_solve(env):
     if s.check() != z3.sat:
         return None
     model = s.model()
-    return {k: bool(model[v].as_long()) for k, v in nck_to_z3.items()}
+    ret = env.Result()
+    ret.solutions = [{k: bool(model[v].as_long()) for k, v in nck_to_z3.items()}]
+    return ret
 
 
 def qubo_solve(env, hard_scale):
@@ -74,9 +76,9 @@ def qubo_solve(env, hard_scale):
         return None
     model = s.model()
     ports = env.ports()
-    return {k: bool(model[v].as_long())
-            for k, v in nck_to_z3.items()
-            if k in ports}
+    ret = env.Result()
+    ret.solutions = [{k: bool(model[v].as_long()) for k, v in nck_to_z3.items()}]
+    return ret
 
 
 def solve(env, qubo=False, hard_scale=None):


### PR DESCRIPTION
Adds the quality function to check number of soft constraints passed
Changes the solve function to return a custom object rather than a single dictionary

Concerns:
Maybe we should return a dictionary of all of the results instead of a custom object; I've seen that often, and it makes it easier to see what's available without digging into the code. If not, we should add a display function to the object so that it can be printed nicer.
I'm thinking we might want to include a 'verbose' variable or something to the solve function. Currently the qiskit solver takes quite a bit longer to connect to the submitted jobs and dig through the qasm to find the number of qubits used and the circuit depth, which not everyone may want. Perhaps it should be optional. The ocean solver is a much smaller addition, and the z3 solver doesn't really have any of that information anyway, so it's mostly a qiskit concern.